### PR TITLE
Renaming the "X-Forwarded-For" header

### DIFF
--- a/public/Jvc.php
+++ b/public/Jvc.php
@@ -558,7 +558,7 @@ class Jvc {
     curl_setopt($ch, CURLOPT_TIMEOUT, 2);
 
     curl_setopt($ch, CURLOPT_COOKIE, $this->cookie_string(['coniunctio' => $coniunctio, 'dlrowolleh' => $dlrowolleh]));
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ['X-Forwaded-For: ' . $_SERVER['REMOTE_ADDR']]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['X-Forwarded-For: ' . $_SERVER['REMOTE_ADDR']]);
 
     $rep = curl_exec($ch);
     $errno = curl_errno($ch);

--- a/public/Jvc.php
+++ b/public/Jvc.php
@@ -558,7 +558,7 @@ class Jvc {
     curl_setopt($ch, CURLOPT_TIMEOUT, 2);
 
     curl_setopt($ch, CURLOPT_COOKIE, $this->cookie_string(['coniunctio' => $coniunctio, 'dlrowolleh' => $dlrowolleh]));
-    curl_setopt($ch, CURLOPT_HTTPHEADER, ['HTTP_X_FORWARDED_FOR: '. $_SERVER['REMOTE_ADDR']]);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['X-Forwaded-For: ' . $_SERVER['REMOTE_ADDR']]);
 
     $rep = curl_exec($ch);
     $errno = curl_errno($ch);


### PR DESCRIPTION
Renaming the `HTTP_X_FORWARDED_FOR` header to match the "non-standard-but-widely-used" way to name it (`X-Forwarded-For`).

Moreover, it was never been sent with the HTTP request (cURL ignores all HTTP headers starting with `HTTP_`), so I guess that name was just a confusion from the fact that PHP prefixes all the HTTP headers by `HTTP_` in its `$_SERVER` variable.

It can also be noted that this header might become obsolete since RFC7239 defines a new `Forwarded` header:
https://tools.ietf.org/html/rfc7239